### PR TITLE
Support Spanish subscribers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo apt update && sudo apt install zlib1g-dev mysql-client libxml2
-      - run: sudo docker-php-ext-install zip pdo pdo_mysql mysqli mbstring tokenizer xml ctype json
+      - run: sudo apt update && sudo apt install zlib1g-dev mysql-client
+      - run: sudo docker-php-ext-install zip pdo pdo_mysql mysqli mbstring tokenizer ctype json
       - run:
           # Our primary container isn't MYSQL so run a sleep command until it's ready.
           name: Waiting for MySQL to be ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
       # Using the RAM variation mitigates I/O contention
       # for database intensive operations.
       - image: circleci/mysql:5.7-ram
+        environment:
+          MYSQL_ROOT_PASSWORD: rootpw
+          MYSQL_DATABASE: homestead_testing
+          MYSQL_USER: forge
       #
       # - image: redis:2.8.19
 
@@ -21,10 +25,6 @@ jobs:
       TWILIO_ACCOUNT_SID: supsupsup
       TWILIO_AUTH_TOKEN: yoyoyo
       TWILIO_FROM_NUMBER: +15555555555
-      MYSQL_ROOT_PASSWORD: rootpw
-      MYSQL_DATABASE: homestead_testing
-      MYSQL_USER: forge
-      MYSQL_PASSWORD: ''
 
     steps:
       - checkout
@@ -74,8 +74,7 @@ jobs:
             - ~/.yarn
 
       # prepare the database
-      - run: touch /home/circleci/project/database/database.sqlite
-      - run: php artisan migrate --env=testing --database=sqlite --force
+      - run: php artisan migrate --env=testing --database=mysql_testing --force
 
       # run tests with phpunit or codecept
       - run: ./vendor/bin/phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,13 @@ jobs:
       TWILIO_ACCOUNT_SID: supsupsup
       TWILIO_AUTH_TOKEN: yoyoyo
       TWILIO_FROM_NUMBER: +15555555555
+      DB_DATABASE: homestead_testing
 
     steps:
       - checkout
 
-      - run: sudo apt update && sudo apt install zlib1g-dev
-      - run: sudo docker-php-ext-install zip
+      - run: sudo apt update && sudo apt install zlib1g-dev mysql-client
+      - run: sudo docker-php-ext-install zip pdo pdo_mysql mysqli mbstring tokenizer xml ctype json
       - run:
           # Our primary container isn't MYSQL so run a sleep command until it's ready.
           name: Waiting for MySQL to be ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # Using the RAM variation mitigates I/O contention
       # for database intensive operations.
-      # - image: circleci/mysql:5.7-ram
+      - image: circleci/mysql:5.7-ram
       #
       # - image: redis:2.8.19
 
@@ -21,12 +21,27 @@ jobs:
       TWILIO_ACCOUNT_SID: supsupsup
       TWILIO_AUTH_TOKEN: yoyoyo
       TWILIO_FROM_NUMBER: +15555555555
+      MYSQL_ROOT_PASSWORD: rootpw
+      MYSQL_DATABASE: homestead_testing
+      MYSQL_USER: forge
+      MYSQL_PASSWORD: ''
 
     steps:
       - checkout
 
-      - run: sudo apt update && sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo apt update && sudo apt install zlib1g-dev
       - run: sudo docker-php-ext-install zip
+      - run:
+        # Our primary container isn't MYSQL so run a sleep command until it's ready.
+        name: Waiting for MySQL to be ready
+        command: |
+          for i in `seq 1 10`;
+          do
+            nc -z 127.0.0.1 3306 && echo Success && exit 0
+            echo -n .
+            sleep 1
+          done
+          echo Failed waiting for MySQL && exit 1
 
       # Download and cache dependencies
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,8 @@ jobs:
       - image: circleci/php:7.1-jessie-node-browsers
       - image: circleci/mysql:8.0.4
         environment:
-          MYSQL_ROOT_PASSWORD: rootpw
+          MYSQL_ROOT_PASSWORD: circleci
           MYSQL_DATABASE: homestead_testing
-          MYSQL_USER: circleci
-          MYSQL_PASSWORD: circleci
           MYSQL_ALLOW_EMPTY_PASSWORD: true
 
     environment:
@@ -20,7 +18,7 @@ jobs:
       TWILIO_AUTH_TOKEN: yoyoyo
       TWILIO_FROM_NUMBER: +15555555555
       DB_DATABASE: homestead_testing
-      DB_USERNAME: circleci
+      DB_USERNAME: root
       DB_PASSWORD: circleci
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,12 @@ jobs:
     docker:
       # Specify the version you desire here
       - image: circleci/php:7.1-jessie-node-browsers
-      - image: circleci/mysql:8.0.4
+      - image: circleci/mysql:5.7-ram
         environment:
-          MYSQL_ROOT_PASSWORD: circleci
+          MYSQL_ROOT_PASSWORD: rootpw
           MYSQL_DATABASE: homestead_testing
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_USER: circleci
+          MYSQL_PASSWORD: circleci
 
     environment:
       # These need to be set, even if not valid Twilio creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,12 @@ jobs:
     docker:
       # Specify the version you desire here
       - image: circleci/php:7.1-jessie-node-browsers
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # Using the RAM variation mitigates I/O contention
-      # for database intensive operations.
-      - image: circleci/mysql:5.7-ram
+      - image: circleci/mysql:8.0.4
         environment:
           MYSQL_ROOT_PASSWORD: rootpw
           MYSQL_DATABASE: homestead_testing
           MYSQL_USER: forge
-      #
-      # - image: redis:2.8.19
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
 
     environment:
       # These need to be set, even if not valid Twilio creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,16 +32,16 @@ jobs:
       - run: sudo apt update && sudo apt install zlib1g-dev
       - run: sudo docker-php-ext-install zip
       - run:
-        # Our primary container isn't MYSQL so run a sleep command until it's ready.
-        name: Waiting for MySQL to be ready
-        command: |
-          for i in `seq 1 10`;
-          do
-            nc -z 127.0.0.1 3306 && echo Success && exit 0
-            echo -n .
-            sleep 1
-          done
-          echo Failed waiting for MySQL && exit 1
+          # Our primary container isn't MYSQL so run a sleep command until it's ready.
+          name: Waiting for MySQL to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z 127.0.0.1 3306 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for MySQL && exit 1
 
       # Download and cache dependencies
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo apt update && sudo apt install zlib1g-dev mysql-client
+      - run: sudo apt update && sudo apt install zlib1g-dev mysql-client libxml2
       - run: sudo docker-php-ext-install zip pdo pdo_mysql mysqli mbstring tokenizer xml ctype json
       - run:
           # Our primary container isn't MYSQL so run a sleep command until it's ready.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       TWILIO_AUTH_TOKEN: yoyoyo
       TWILIO_FROM_NUMBER: +15555555555
       DB_DATABASE: homestead_testing
-      DB_USERNAME: root
+      DB_USERNAME: circleci
       DB_PASSWORD: circleci
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
         environment:
           MYSQL_ROOT_PASSWORD: rootpw
           MYSQL_DATABASE: homestead_testing
-          MYSQL_USER: forge
+          MYSQL_USER: circleci
+          MYSQL_PASSWORD: circleci
           MYSQL_ALLOW_EMPTY_PASSWORD: true
 
     environment:
@@ -19,6 +20,8 @@ jobs:
       TWILIO_AUTH_TOKEN: yoyoyo
       TWILIO_FROM_NUMBER: +15555555555
       DB_DATABASE: homestead_testing
+      DB_USERNAME: circleci
+      DB_PASSWORD: circleci
 
     steps:
       - checkout

--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -1,0 +1,34 @@
+---
+ip: "192.168.10.10"
+memory: 2048
+cpus: 2
+provider: virtualbox
+
+authorize: ~/.ssh/id_rsa.pub
+
+keys:
+    - ~/.ssh/id_rsa
+
+folders:
+    - map: ~/code/voteict
+      to: /home/vagrant/code
+
+sites:
+    - map: homestead.local
+      to: /home/vagrant/code/public
+
+databases:
+    - homestead
+    - homestead_testing
+
+features:
+    - mariadb: false
+    - ohmyzsh: false
+    - webdriver: false
+
+# ports:
+#     - send: 50000
+#       to: 5000
+#     - send: 7777
+#       to: 777
+#       protocol: udp

--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -3,6 +3,7 @@ ip: "192.168.10.10"
 memory: 2048
 cpus: 2
 provider: virtualbox
+version: 7.2.1
 
 authorize: ~/.ssh/id_rsa.pub
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,19 @@ First, you'll need to run `composer install` to install our dependencies.
 
 The recommended way to get the application running locally is to use [Homestead](https://laravel.com/docs/5.6/homestead).
 
-Mainly, run `vagrant up`, and then the site should be available at
+_Note: if you have a global Homestead setup already, these instructions may not
+work correctly._
+
+As a quickstart, you can copy `Homestead.yaml.example` to `Homestead.yaml`, and
+update the line pointing to where the voteict code is stored locally.
+
+Second, you will want to put an `/etc/hosts` entry for..
+
+```
+192.168.10.10 homestead.local
+```
+
+Then, run `vagrant up`, and then the site should be available at
 localhost:8000. Most commands that you will need run will need to be run inside
 the vagrant box, so do `vagrant ssh` first and `cd` into `~/code`.
 

--- a/app/Console/Commands/SendScheduledMessages.php
+++ b/app/Console/Commands/SendScheduledMessages.php
@@ -51,9 +51,15 @@ class SendScheduledMessages extends Command
 
                 foreach ($subscribers as $subscriber) {
                     foreach ($scheduled_messages as $message) {
+                        $body = $message->body_en;
+                        switch ($subscriber->locale) {
+                        case 'es':
+                            $body = $message->body_es;
+                            break;
+                        }
                         $sms->send(
                             $subscriber->number,
-                            $message->body,
+                            $body,
                             ['scheduled_message_id' => $message->id]
                         );
 

--- a/app/Console/Commands/SendScheduledMessages.php
+++ b/app/Console/Commands/SendScheduledMessages.php
@@ -54,7 +54,9 @@ class SendScheduledMessages extends Command
                         $body = $message->body_en;
                         switch ($subscriber->locale) {
                         case 'es':
-                            $body = $message->body_es;
+                            if ($message->body_es && $message->body_es != '') {
+                                $body = $message->body_es;
+                            }
                             break;
                         }
                         $sms->send(

--- a/app/Http/Controllers/ScheduledMessageController.php
+++ b/app/Http/Controllers/ScheduledMessageController.php
@@ -35,7 +35,8 @@ class ScheduledMessageController extends Controller
 
     function create (Request $request) {
         $validator = Validator::make($request->all(), [
-            'body' => 'required|max:260',
+            'body_en' => 'required|max:260',
+            'body_es' => 'required|max:260',
             'send_at' => 'required|date|after:now',
         ]);
 
@@ -46,7 +47,8 @@ class ScheduledMessageController extends Controller
         }
 
         ScheduledMessage::create([
-            'body' => $request->input('body'),
+            'body_en' => $request->input('body_en'),
+            'body_es' => $request->input('body_es'),
             'send_at' => new Carbon($request->input('send_at')),
         ]);
 
@@ -72,7 +74,8 @@ class ScheduledMessageController extends Controller
         }
 
         $validator = Validator::make($request->all(), [
-            'body' => 'required|max:260',
+            'body_en' => 'required|max:260',
+            'body_es' => 'required|max:260',
             'send_at' => 'required|date|after:now',
         ]);
 
@@ -81,7 +84,8 @@ class ScheduledMessageController extends Controller
                 ->withErrors($validator);
         }
 
-        $scheduled_message->body = $request->input('body');
+        $scheduled_message->body_en = $request->input('body_en');
+        $scheduled_message->body_es = $request->input('body_es');
         $scheduled_message->send_at = $request->input('send_at');
         $scheduled_message->save();
 

--- a/app/Http/Controllers/ScheduledMessageController.php
+++ b/app/Http/Controllers/ScheduledMessageController.php
@@ -86,7 +86,7 @@ class ScheduledMessageController extends Controller
 
         $scheduled_message->body_en = $request->input('body_en');
         $scheduled_message->body_es = $request->input('body_es');
-        $scheduled_message->send_at = $request->input('send_at');
+        $scheduled_message->send_at = new Carbon($request->input('send_at'));
         $scheduled_message->save();
 
         return redirect('/admin/scheduled_messages');

--- a/app/ScheduledMessage.php
+++ b/app/ScheduledMessage.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class ScheduledMessage extends Model
 {
     protected $fillable = [
-        'body', 'send_at', 'sent',
+        'body_en', 'body_es', 'send_at', 'sent',
     ];
 
     protected $dates = [
@@ -32,7 +32,8 @@ class ScheduledMessage extends Model
 
     public function getHtmlAttribute()
     {
+        // TODO: show Spanish version here too
         // LinkFinder in `yarri/link-finder` package
-        return (new \LinkFinder)->process($this->attributes['body']);
+        return (new \LinkFinder)->process($this->attributes['body_en']);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "type": "project",
     "require": {
         "php": "^7.1.3",
+        "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.7.*",
         "laravel/tinker": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16aaf40e786ac3a301a80f4288afafc7",
+    "content-hash": "f755b0d06fa29cf1ce98dcb15e0ab398",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -38,6 +38,237 @@
             ],
             "description": "implementation of xdg base directory specification for php",
             "time": "2014-10-24T07:27:01+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2018-08-21T18:01:43+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "reference": "22800bd651c1d8d2a9719e2a3dc46d5108ebfcc9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "jetbrains/phpstorm-stubs": "^2018.1.2",
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.4",
+                "symfony/console": "^2.0.5|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "dbal",
+                "mysql",
+                "persistence",
+                "pgsql",
+                "php",
+                "queryobject"
+            ],
+            "time": "2018-12-31T03:27:51+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Doctrine Event Manager component",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "eventdispatcher",
+                "eventmanager"
+            ],
+            "time": "2018-06-11T11:59:03+00:00"
         },
         {
             "name": "doctrine/inflector",

--- a/config/database.php
+++ b/config/database.php
@@ -54,6 +54,21 @@ return [
             'engine' => null,
         ],
 
+        'mysql_testing' => [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => 'homestead_testing',
+            'username' => env('DB_USERNAME', 'forge'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'strict' => true,
+            'engine' => null,
+        ],
+
         'pgsql' => [
             'driver' => 'pgsql',
             'host' => env('DB_HOST', '127.0.0.1'),

--- a/database/factories/ScheduledMessageFactory.php
+++ b/database/factories/ScheduledMessageFactory.php
@@ -5,7 +5,8 @@ use Carbon\Carbon;
 
 $factory->define(App\ScheduledMessage::class, function (Faker $faker) {
     return [
-        'body' => $faker->text(160),
+        'body_en' => $faker->text(160),
+        'body_es' => $faker->text(160),
         'send_at' => Carbon::create()->addMinutes(1)->toDateTimeString(),
         'sent' => false,
     ];

--- a/database/migrations/2019_07_20_080248_add_locales_to_scheduled_messages.php
+++ b/database/migrations/2019_07_20_080248_add_locales_to_scheduled_messages.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLocalesToScheduledMessages extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('scheduled_messages', function ($table) {
+            $table->text('body_es')->nullable()->after('body');
+            $table->renameColumn('body', 'body_en');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('scheduled_messages', function ($table) {
+            $table->dropColumn('body_es');
+            $table->renameColumn('body_en', 'body');
+        });
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,7 +28,6 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="MAIL_DRIVER" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="mysql_testing"/>
     </php>
 </phpunit>

--- a/resources/lang/en/sms.php
+++ b/resources/lang/en/sms.php
@@ -7,6 +7,7 @@ return [
     |--------------------------------------------------------------------------
     */
 
+    // TODO: Get these translated
     'subscribed'   => 'Thanks for subscribing! Text STOP to unsubscribe. Need to register to vote? Go to https://bit.ly/voteictregister to do it now, right from your phone!',
-    'unsubscribed' => 'You have been unsubscribed! Text SUBSCRIBE again to resubscribe.',
+    'unsubscribed' => 'You have been unsubscribed! Text SUBSCRIBE again to sign back up.',
 ];

--- a/resources/views/admin/scheduled_messages/form.blade.php
+++ b/resources/views/admin/scheduled_messages/form.blade.php
@@ -3,8 +3,13 @@
 <form id="scheduled_message_form" action="/admin/scheduled_messages{{ $scheduled_message->exists ? '/' . $scheduled_message->id : '' }}" method="POST">
     @csrf
     <div class="form-group">
-        <label class="form-label" for="body">Body</label>
-        <textarea class="form-control" name="body" id="body" cols="30" rows="3">{{ $scheduled_message->body }}</textarea>
+        <label class="form-label" for="body_en">Body (English)</label>
+        <textarea class="form-control" name="body_en" id="body_en" cols="30" rows="3">{{ $scheduled_message->body_en }}</textarea>
+    </div>
+
+    <div class="form-group">
+        <label class="form-label" for="body_es">Body (Spanish)</label>
+        <textarea class="form-control" name="body_es" id="body_es" cols="30" rows="3">{{ $scheduled_message->body_es }}</textarea>
     </div>
 
     <div class="form-group">

--- a/resources/views/admin/scheduled_messages/index.blade.php
+++ b/resources/views/admin/scheduled_messages/index.blade.php
@@ -18,7 +18,8 @@
                             <tr>
                                 <th>Sent</th>
                                 <th>Send At</th>
-                                <th>Body</th>
+                                <th>Body (en)</th>
+                                <th>Body (es)</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
@@ -27,7 +28,8 @@
                                 <tr>
                                     <td>{{ $scheduled_message->sent ? 'X' : '' }}</td>
                                     <td>{{ $scheduled_message->send_at->format('m/d/Y g:i A') }}</td>
-                                    <td>{{ $scheduled_message->body }}</td>
+                                    <td>{{ $scheduled_message->body_en }}</td>
+                                    <td>{{ $scheduled_message->body_es }}</td>
                                     <td>
                                     @if ($scheduled_message->sent)
                                         <!-- TODO: create a send report view -->

--- a/tests/Feature/ScheduledMessagesTest.php
+++ b/tests/Feature/ScheduledMessagesTest.php
@@ -31,7 +31,8 @@ class ScheduledMessagesTest extends TestCase
         $request->assertRedirect('/admin/scheduled_messages');
 
         $this->assertDatabaseHas('scheduled_messages', [
-            'body' => $message->body,
+            'body_en' => $message->body_en,
+            'body_es' => $message->body_es,
             'send_at' => $message->send_at,
             'sent' => false,
         ]);
@@ -56,7 +57,8 @@ class ScheduledMessagesTest extends TestCase
         $request->assertRedirect('/admin/scheduled_messages/new');
 
         $this->assertDatabaseMissing('scheduled_messages', [
-            'body' => $message->body,
+            'body_en' => $message->body_en,
+            'body_es' => $message->body_es,
             'send_at' => $message->send_at,
         ]);
     }
@@ -70,12 +72,14 @@ class ScheduledMessagesTest extends TestCase
     {
         $user = factory(User::class)->create([ 'admin' => true ]);
         $message = factory(ScheduledMessage::class)->create();
-        $newBody = 'New message body!';
+        $newBodyEN = 'New!';
+        $newBodyES = 'Nuevo!';
 
         $request = $this
             ->actingAs($user)
             ->put('/admin/scheduled_messages/' . $message->id, [
-                'body' => $newBody,
+                'body_en' => $newBodyEN,
+                'body_es' => $newBodyES,
                 'send_at' => $message->send_at,
             ]);
 
@@ -83,7 +87,8 @@ class ScheduledMessagesTest extends TestCase
 
         $this->assertDatabaseHas('scheduled_messages', [
             'id' => $message->id,
-            'body' => $newBody,
+            'body_en' => $newBodyEN,
+            'body_es' => $newBodyES,
             'send_at' => $message->send_at,
         ]);
     }
@@ -99,7 +104,8 @@ class ScheduledMessagesTest extends TestCase
         $message = factory(ScheduledMessage::class)->create();
         $messageAttrCheck = [
             'id' => $message->id,
-            'body' => $message->body,
+            'body_en' => $message->body_en,
+            'body_es' => $message->body_es,
             // We don't check send at because the DB record includes seconds
         ];
 
@@ -128,7 +134,8 @@ class ScheduledMessagesTest extends TestCase
 
         $messageAttrCheck = [
             'id' => $message->id,
-            'body' => $message->body,
+            'body_en' => $message->body_en,
+            'body_es' => $message->body_es,
         ];
 
         $this->assertDatabaseHas('scheduled_messages', $messageAttrCheck);
@@ -144,7 +151,7 @@ class ScheduledMessagesTest extends TestCase
         $request = $this
             ->actingAs($user)
             ->put('/admin/scheduled_messages/' . $message->id, [
-                'body' => 'sup',
+                'body_en' => 'sup',
             ]);
 
         $request->assertRedirect('/admin/scheduled_messages');
@@ -154,7 +161,7 @@ class ScheduledMessagesTest extends TestCase
 
     /**
      * Test viewing sent messages of a processed scheduled message.
-     * 
+     *
      * @return void
      */
     public function testViewMessagesOfSentScheduledMessage()
@@ -175,7 +182,8 @@ class ScheduledMessagesTest extends TestCase
 
         // expect to see each of the messages sent
         foreach ($messages as $message) {
-            $request->assertSee($message->body);
+            $request->assertSee($message->body_en);
+            $request->assertSee($message->body_es);
             $request->assertSee($message->to);
         }
     }


### PR DESCRIPTION
- Adds the ability to provide a Spanish translation for scheduled messages.
- Will send Spanish text to any `es` subscribers.

Misc
- Add `Homestead.yaml.example`
- Switch testing db to mysql
- Updated CircleCI to use mysql
- Slight documentation updates

Closes #25