### PR TITLE
SMS link to include number and language keyword for message body

### DIFF
--- a/resources/lang/en/home.php
+++ b/resources/lang/en/home.php
@@ -10,6 +10,7 @@ return [
 
     'tagline' => 'Helping you be <strong>locally</strong> engaged.',
     'text_subscribe_cta' => 'Text <strong>START</strong> or <strong>INICIAR</strong> to <strong><a href=":link">864-ICT-VOTE</a></strong>',
+    'text_subscribe_keyword' => 'START',
     'add_to_contacts_cta' => '..and be sure to <a href=":link">add VoteICT to your contacts</a>!',
     'locale_support_head' => 'Spanish available!',
     'locale_support_body' => 'Text <strong>SPANISH</strong> any time to switch your preference, and <strong>ENGLISH</strong> to switch back.',

--- a/resources/lang/es/home.php
+++ b/resources/lang/es/home.php
@@ -10,6 +10,7 @@ return [
 
     'tagline' => 'Ayudandole a participar <strong>localmente</strong>.',
     'text_subscribe_cta' => 'Para empezar envie la palabra INICIAR a <a href=":link">864-ICT-VOTE</a>',
+    'text_subscribe_keyword' => 'INICIAR',
     'add_to_contacts_cta' => '..y asegúrese de <a href=":link">agregar Vote ICT a sus contactos</a>!',
     'locale_support_head' => 'Español apoyado!',
     'locale_support_body' => 'Envía <strong>ESPAÑOL</strong> en cualquier momento para cambiar tu preferencia, e <strong>INGLÉS</strong> para volver a cambiar.',

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -17,7 +17,7 @@
     <div class="row justify-content-center">
         <div class="col-md-12 my-5">
             <h1 class="text-center">
-                @lang('home.text_subscribe_cta', ['link' => 'tel:+1' . env('TWILIO_FROM_NUMBER')])
+                @lang('home.text_subscribe_cta', ['link' => 'sms://+1' . env('TWILIO_FROM_NUMBER') . ';?&body=' . __('home.text_subscribe_keyword')])
             </h1>
             <h2 class="text-center">
                 @lang('home.add_to_contacts_cta', ['link' => 'tel:+1' . env('TWILIO_FROM_NUMBER')])


### PR DESCRIPTION
Addressing issue #54 

Through investigating alternatives to using "sms-link", I found a suggestion (buried in [StackOverflow](https://stackoverflow.com/questions/6480462/how-to-pre-populate-the-sms-body-text-via-an-html-link/28486352#28486352) comments) to use the ';?&' method with sms to allow browsers to pickup the body text. 

I was able to test with most of my own IOS devices, but only had access to a single test Android device (that worked). 

To also assist with multi-language support, I included the ability for the appropriate language keyword to be passed based on selected language. 

