### PR TITLE
Allow for SMS or Twitter to be selected as targets for messages  (#62)

### DIFF
--- a/app/Http/Controllers/ScheduledMessageController.php
+++ b/app/Http/Controllers/ScheduledMessageController.php
@@ -27,6 +27,8 @@ class ScheduledMessageController extends Controller
 
     function new () {
         $scheduled_message = new ScheduledMessage();
+        $scheduled_message->target_sms = true;
+        $scheduled_message->target_twitter = true;
         $scheduled_message->send_at = Carbon::now()->add(CarbonInterval::hours(1));
         return view('admin.scheduled_messages.new', [
             'scheduled_message' => $scheduled_message,
@@ -37,6 +39,8 @@ class ScheduledMessageController extends Controller
         $validator = Validator::make($request->all(), [
             'body_en' => 'required|max:260',
             'body_es' => 'required|max:260',
+            'target_sms' => 'required_without:target_twitter',
+            'target_twitter' => 'required_without:target_sms',
             'send_at' => 'required|date|after:now',
         ]);
 
@@ -49,6 +53,8 @@ class ScheduledMessageController extends Controller
         ScheduledMessage::create([
             'body_en' => $request->input('body_en'),
             'body_es' => $request->input('body_es'),
+            'target_sms' => $request->input('target_sms'),
+            'target_twitter' => $request->input('target_twitter'),
             'send_at' => new Carbon($request->input('send_at')),
         ]);
 
@@ -76,6 +82,8 @@ class ScheduledMessageController extends Controller
         $validator = Validator::make($request->all(), [
             'body_en' => 'required|max:260',
             'body_es' => 'required|max:260',
+            'target_sms' => 'required_without:target_twitter',
+            'target_twitter' => 'required_without:target_sms',
             'send_at' => 'required|date|after:now',
         ]);
 
@@ -86,6 +94,8 @@ class ScheduledMessageController extends Controller
 
         $scheduled_message->body_en = $request->input('body_en');
         $scheduled_message->body_es = $request->input('body_es');
+        $scheduled_message->target_sms = $request->input('target_sms');
+        $scheduled_message->target_twitter = $request->input('target_twitter');
         $scheduled_message->send_at = new Carbon($request->input('send_at'));
         $scheduled_message->save();
 

--- a/app/ScheduledMessage.php
+++ b/app/ScheduledMessage.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 class ScheduledMessage extends Model
 {
     protected $fillable = [
-        'body_en', 'body_es', 'send_at', 'sent',
+        'body_en', 'body_es', 'send_at', 'sent', 'target_sms', 'target_twitter'
     ];
 
     protected $dates = [

--- a/database/migrations/2019_10_19_204517_add_targets_to_scheduled_messages.php
+++ b/database/migrations/2019_10_19_204517_add_targets_to_scheduled_messages.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTargetsToScheduledMessages extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('scheduled_messages', function (Blueprint $table) {
+            $table->text('target_sms')->nullable();
+            $table->text('target_twitter')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('scheduled_messages', function (Blueprint $table) {
+            $table->dropColumn('target_sms');
+            $table->dropColumn('target_twitter');
+        });
+    }
+}

--- a/resources/views/admin/scheduled_messages/form.blade.php
+++ b/resources/views/admin/scheduled_messages/form.blade.php
@@ -15,6 +15,20 @@
             <textarea class="form-control" name="body_es" id="body_es" cols="30" rows="3">{{ $scheduled_message->body_es }}</textarea>
         </character-count>
     </div>
+    
+    <div class="form-group">
+        <label class="form-label">Targets</label>
+        <div class="form-control">
+            <div class="custom-control custom-checkbox custom-control-inline">
+                <input type="checkbox" class="custom-control-input" name="target_sms" id="target_sms" @if($scheduled_message->target_sms) checked @endif>
+                <label class="custom-control-label" for="target_sms">SMS</label>
+            </div>
+            <div class="custom-control custom-checkbox custom-control-inline">
+                <input type="checkbox" class="custom-control-input" name="target_twitter" id="target_twitter" @if($scheduled_message->target_twitter) checked @endif>
+                <label class="custom-control-label" for="target_twitter">Twitter</label>
+            </div>
+        </div>
+    </div>
 
     <div class="form-group">
         <label class="form-label" for="send_at">Send At</label>

--- a/resources/views/admin/scheduled_messages/index.blade.php
+++ b/resources/views/admin/scheduled_messages/index.blade.php
@@ -17,6 +17,7 @@
                         <thead>
                             <tr>
                                 <th>Sent</th>
+                                <th>Target</th>
                                 <th>Send At</th>
                                 <th>Body (en)</th>
                                 <th>Body (es)</th>
@@ -27,6 +28,11 @@
                             @foreach ($scheduled_messages as $scheduled_message)
                                 <tr>
                                     <td>{{ $scheduled_message->sent ? 'X' : '' }}</td>
+                                    <td>
+                                        @if( $scheduled_message->target_sms ) SMS @endif 
+                                        @if( $scheduled_message->target_sms and $scheduled_message->target_twitter ) / @endif 
+                                        @if( $scheduled_message->target_twitter ) Twitter @endif
+                                    </td>
                                     <td>{{ $scheduled_message->send_at->format('m/d/Y g:i A') }}</td>
                                     <td>{{ $scheduled_message->body_en }}</td>
                                     <td>{{ $scheduled_message->body_es }}</td>


### PR DESCRIPTION
Working to implement #62

I needed to create a migration to include two new database columns for tracking the SMS or Twitter selections. I then modified the new and update controller to map to the new column, but included a validation to catch that at least one checkbox is selected. I don't 100% like the way the error message comes across, but would like some feedback if that needs to be implemented within this PR. 

I also modified the SendScheduledMessages command so it will respect the target selection as it loops through the messages that need sent. 

This enhancement was a big learning for me, so any guidance on changes/additions/removals would be appreciated. 